### PR TITLE
dockerfile 작성

### DIFF
--- a/practice_2/Dockerfile.dev
+++ b/practice_2/Dockerfile.dev
@@ -1,0 +1,11 @@
+FROM node:alpine
+
+WORKDIR /usr/src/app
+
+COPY package.json ./
+
+RUN npm install
+
+COPY ./ ./
+
+CMD ["npm", "run", "start"]


### PR DESCRIPTION
환경별 dockerfile을 작성(Dockerfile.dev)
shell 명령어 default로 찾는 Dockerfile이 존해하지 않으므로 -f 옵션으로 파일을 지정해주어야함

docker build -f Dockerfile.dev -t alsgur8993/docekr-react-app ./

